### PR TITLE
fix: dto에 전체 페이지 수, 유저 프로필과 작성일자 포함하도록 구현

### DIFF
--- a/src/main/java/com/blog/domain/board/application/dto/PostReadAllResponse.java
+++ b/src/main/java/com/blog/domain/board/application/dto/PostReadAllResponse.java
@@ -1,35 +1,18 @@
 package com.blog.domain.board.application.dto;
 
-import com.blog.domain.board.domain.entity.Post;
-import com.blog.domain.comment.domain.entity.Comment;
-import com.blog.domain.user.domain.entity.User;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
-import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
-import java.util.UUID;
+
 import lombok.Builder;
 
 @Builder
 public record PostReadAllResponse(
-        @Schema(description = "게시글 id", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
-        UUID postId,
-        @Schema(description = "게시글 제목", example = "게시글 제목")
-        String title,
-        @ArraySchema(arraySchema = @Schema(implementation = ContentDto.class))
-        List<ContentDto> contents,
-        @Schema(description = "게시글 소유 여부", example = "true")
-        Boolean isOwner,
-        @Schema(description = "댓글 개수", example = "1")
-        int commentCount
+	List<PostReadResponse> post,
+	long pageMax
 ) {
-    public static PostReadAllResponse toResponse(Post post, User user, List<ContentDto> contentDtos,
-                                                 List<Comment> comments) {
-        return PostReadAllResponse.builder()
-                .postId(post.getId())
-                .title(post.getTitle())
-                .contents(contentDtos)
-                .isOwner(user != null && post.getUser().equals(user))
-                .commentCount(comments.size())
-                .build();
-    }
+	public static PostReadAllResponse toResponse(List<PostReadResponse> postDtos, int pageSize) {
+		return PostReadAllResponse.builder()
+			.post(postDtos)
+			.pageMax(pageSize)
+			.build();
+	}
 }

--- a/src/main/java/com/blog/domain/board/application/usecase/PostManageUsecase.java
+++ b/src/main/java/com/blog/domain/board/application/usecase/PostManageUsecase.java
@@ -1,6 +1,12 @@
 package com.blog.domain.board.application.usecase;
 
-import com.blog.domain.board.application.dto.ContentDto;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.blog.domain.board.application.dto.PostCreateRequest;
 import com.blog.domain.board.application.dto.PostReadAllResponse;
 import com.blog.domain.board.application.dto.PostReadResponse;
@@ -20,105 +26,106 @@ import com.blog.domain.comment.domain.service.CommentDeleteService;
 import com.blog.domain.comment.domain.service.CommentGetService;
 import com.blog.domain.user.domain.entity.User;
 import com.blog.domain.user.domain.service.UserGetService;
-import java.util.List;
-import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class PostManageUsecase {
-    private final UserGetService userGetService;
-    private final PostSaveService postSaveService;
-    private final PostGetService postGetService;
-    private final PostUpdateService postUpdateService;
-    private final PostValidateService postValidateService;
-    private final PostDeleteService postDeleteService;
-    private final CommentGetService commentGetService;
-    private final CommentDeleteService commentDeleteService;
-    private final ContentSaveService contentCreateService;
-    private final ContentGetService contentGetService;
-    private final ContentDeleteService contentDeleteService;
+	private final UserGetService userGetService;
+	private final PostSaveService postSaveService;
+	private final PostGetService postGetService;
+	private final PostUpdateService postUpdateService;
+	private final PostValidateService postValidateService;
+	private final PostDeleteService postDeleteService;
+	private final CommentGetService commentGetService;
+	private final CommentDeleteService commentDeleteService;
+	private final ContentSaveService contentCreateService;
+	private final ContentGetService contentGetService;
+	private final ContentDeleteService contentDeleteService;
 
-    @Transactional
-    public void createPost(Long userId, PostCreateRequest dto) {
-        User user = userGetService.find(userId);
-        Post post = Post.CreatePost(dto.title(), user);
+	@Transactional
+	public void createPost(Long userId, PostCreateRequest dto) {
+		User user = userGetService.find(userId);
+		Post post = Post.CreatePost(dto.title(), user);
 
-        contentCreateService.create(dto.contents(), post);
-        postSaveService.save(post);
-    }
+		contentCreateService.create(dto.contents(), post);
+		postSaveService.save(post);
+	}
 
-    @Transactional(readOnly = true)
-    public PostReadResponse readPost(Long userId, UUID postId) {
-        User user = userGetService.find(userId);
-        Post post = postGetService.find(postId);
+	@Transactional(readOnly = true)
+	public PostReadResponse readPost(Long userId, UUID postId) {
+		User user = userGetService.find(userId);
+		Post post = postGetService.find(postId);
 
-        List<Comment> comments = commentGetService.findALlByPost(post);
-        List<Content> contents = contentGetService.findAll(post);
+		List<Comment> comments = commentGetService.findALlByPost(post);
+		List<Content> contents = contentGetService.findAll(post);
 
-        return PostReadResponse.toResponse(post, user, contents, comments);
-    }
+		return PostReadResponse.toResponse(post, user, contents, comments);
+	}
 
-    @Transactional(readOnly = true)
-    public PostReadResponse readPostNoToken(UUID postId) {
-        Post post = postGetService.find(postId);
-        List<Comment> comments = commentGetService.findALlByPost(post);
-        List<Content> contents = contentGetService.findAll(post);
+	@Transactional(readOnly = true)
+	public PostReadResponse readPostNoToken(UUID postId) {
+		Post post = postGetService.find(postId);
+		List<Comment> comments = commentGetService.findALlByPost(post);
+		List<Content> contents = contentGetService.findAll(post);
 
-        return PostReadResponse.toResponse(post, null, contents, comments);
-    }
+		return PostReadResponse.toResponse(post, null, contents, comments);
+	}
 
-    @Transactional(readOnly = true)
-    public List<PostReadAllResponse> readAllPost(Long userId, int size, int page) {
-        User user = userGetService.find(userId);
-        List<Post> posts = postGetService.findAll(size, page);
+	@Transactional(readOnly = true)
+	public PostReadAllResponse readAllPost(Long userId, int size, int page) {
+		User user = userGetService.find(userId);
+		Page<Post> postPage = postGetService.findAll(size, page);
+		List<Post> posts = postPage.getContent();
 
-        return posts.stream()
-                .map(post -> {
-                    List<Content> contents = contentGetService.findAll(post);
-                    List<Comment> comments = commentGetService.findALlByPost(post);
-                    return PostReadAllResponse.toResponse(post, user,
-                            contents.stream().map(ContentDto::fromContent).toList(), comments);
-                }).toList();
-    }
+		List<PostReadResponse> dtos = posts.stream()
+			.map(post -> {
+				List<Content> contents = contentGetService.findAll(post);
+				List<Comment> comments = commentGetService.findALlByPost(post);
+				return PostReadResponse.toResponse(post, user, contents, comments);
+			}).toList();
 
-    @Transactional(readOnly = true)
-    public List<PostReadAllResponse> readAllPostNoToken(int size, int page) {
-        List<Post> posts = postGetService.findAll(size, page);
+		return PostReadAllResponse.toResponse(dtos, postPage.getTotalPages());
+	}
 
-        return posts.stream()
-                .map(post -> {
-                    List<Content> contents = contentGetService.findAll(post);
-                    List<Comment> comments = commentGetService.findALlByPost(post);
-                    return PostReadAllResponse.toResponse(post, null,
-                            contents.stream().map(ContentDto::fromContent).toList(), comments);
-                }).toList();
-    }
+	@Transactional(readOnly = true)
+	public PostReadAllResponse readAllPostNoToken(int size, int page) {
+		Page<Post> postPage = postGetService.findAll(size, page);
+		List<Post> posts = postPage.getContent();
 
-    @Transactional
-    public void updatePost(Long userId, UUID postId, PostUpdateRequest dto) {
-        User user = userGetService.find(userId);
-        Post post = postGetService.find(postId);
+		List<PostReadResponse> dtos = posts.stream()
+			.map(post -> {
+				List<Content> contents = contentGetService.findAll(post);
+				List<Comment> comments = commentGetService.findALlByPost(post);
+				return PostReadResponse.toResponse(post, null, contents, comments);
+			}).toList();
 
-        postValidateService.certificate(post, user);
+		return PostReadAllResponse.toResponse(dtos, postPage.getTotalPages());
+	}
 
-        contentDeleteService.deleteAllByPost(post);
-        contentCreateService.create(dto.contents(), post);
+	@Transactional
+	public void updatePost(Long userId, UUID postId, PostUpdateRequest dto) {
+		User user = userGetService.find(userId);
+		Post post = postGetService.find(postId);
 
-        postUpdateService.update(post, dto);
-    }
+		postValidateService.certificate(post, user);
 
-    @Transactional
-    public void deletePost(Long userId, UUID postId) {
-        User user = userGetService.find(userId);
-        Post post = postGetService.find(postId);
+		contentDeleteService.deleteAllByPost(post);
+		contentCreateService.create(dto.contents(), post);
 
-        postValidateService.certificate(post, user);
+		postUpdateService.update(post, dto);
+	}
 
-        contentDeleteService.deleteAllByPost(post);
-        commentDeleteService.deleteAll(post);
-        postDeleteService.delete(post);
-    }
+	@Transactional
+	public void deletePost(Long userId, UUID postId) {
+		User user = userGetService.find(userId);
+		Post post = postGetService.find(postId);
+
+		postValidateService.certificate(post, user);
+
+		contentDeleteService.deleteAllByPost(post);
+		commentDeleteService.deleteAll(post);
+		postDeleteService.delete(post);
+	}
 }

--- a/src/main/java/com/blog/domain/board/domain/service/PostGetService.java
+++ b/src/main/java/com/blog/domain/board/domain/service/PostGetService.java
@@ -1,27 +1,30 @@
 package com.blog.domain.board.domain.service;
 
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
 import com.blog.domain.board.domain.entity.Post;
 import com.blog.domain.board.domain.repository.PostRepository;
 import com.blog.domain.board.exception.PostNotFoundException;
-import org.springframework.data.domain.Pageable;
-import java.util.List;
-import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class PostGetService {
-    private final PostRepository postRepository;
+	private final PostRepository postRepository;
 
-    public Post find(UUID postId) {
-        return postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
-    }
+	public Post find(UUID postId) {
+		return postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
+	}
 
-    public List<Post> findAll(int size, int page) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-        return postRepository.findAll(pageable).getContent();
-    }
+	public Page<Post> findAll(int size, int page) {
+		Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+		return postRepository.findAll(pageable);
+	}
 }

--- a/src/main/java/com/blog/domain/board/presentation/PostController.java
+++ b/src/main/java/com/blog/domain/board/presentation/PostController.java
@@ -1,26 +1,9 @@
 package com.blog.domain.board.presentation;
 
-import static com.blog.domain.board.presentation.constant.ResponseMessage.CREATE_SUCCESS;
-import static com.blog.domain.board.presentation.constant.ResponseMessage.DELETE_SUCCESS;
-import static com.blog.domain.board.presentation.constant.ResponseMessage.READ_SUCCESS;
-import static com.blog.domain.board.presentation.constant.ResponseMessage.UPDATE_SUCCESS;
+import static com.blog.domain.board.presentation.constant.ResponseMessage.*;
 
-import com.blog.domain.board.application.dto.PostCreateRequest;
-import com.blog.domain.board.application.dto.PostReadAllResponse;
-import com.blog.domain.board.application.dto.PostReadResponse;
-import com.blog.domain.board.application.dto.PostUpdateRequest;
-import com.blog.domain.board.application.usecase.PostManageUsecase;
-import com.blog.global.common.auth.MemberContext;
-import com.blog.global.common.auth.annotations.UseGuards;
-import com.blog.global.common.auth.guards.MemberGuard;
-import com.blog.global.common.dto.ResponseDto;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import java.util.List;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -31,74 +14,90 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.blog.domain.board.application.dto.PostCreateRequest;
+import com.blog.domain.board.application.dto.PostReadAllResponse;
+import com.blog.domain.board.application.dto.PostReadResponse;
+import com.blog.domain.board.application.dto.PostUpdateRequest;
+import com.blog.domain.board.application.usecase.PostManageUsecase;
+import com.blog.global.common.auth.MemberContext;
+import com.blog.global.common.auth.annotations.UseGuards;
+import com.blog.global.common.auth.guards.MemberGuard;
+import com.blog.global.common.dto.ResponseDto;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
 @Tag(name = "POST")
 @RestController
 @RequestMapping("/posts")
 @RequiredArgsConstructor
 public class PostController {
-    private final PostManageUsecase postManageUsecase;
+	private final PostManageUsecase postManageUsecase;
 
-    @PostMapping
-    @Operation(summary = "게시물 생성")
-    @UseGuards({MemberGuard.class})
-    public ResponseDto<Void> create(@Valid @RequestBody PostCreateRequest dto) {
-        postManageUsecase.createPost(MemberContext.getMember().id(), dto);
-        return ResponseDto.of(HttpStatus.CREATED.value(), CREATE_SUCCESS.getMessage());
-    }
+	@PostMapping
+	@Operation(summary = "게시물 생성")
+	@UseGuards({MemberGuard.class})
+	public ResponseDto<Void> create(@Valid @RequestBody PostCreateRequest dto) {
+		postManageUsecase.createPost(MemberContext.getMember().id(), dto);
+		return ResponseDto.of(HttpStatus.CREATED.value(), CREATE_SUCCESS.getMessage());
+	}
 
-    @GetMapping("/token")
-    @Operation(summary = "게시물 조회")
-    @UseGuards({MemberGuard.class})
-    public ResponseDto<PostReadResponse> read(
-            @Parameter(description = "조회할 게시물 id", example = "62d0e871-500c-45f2-893a-4f90fee5da99") @RequestParam UUID postId) {
-        PostReadResponse response = postManageUsecase.readPost(MemberContext.getMember().id(), postId);
-        return ResponseDto.of(HttpStatus.OK.value(), READ_SUCCESS.getMessage(), response);
-    }
+	@GetMapping("/token")
+	@Operation(summary = "게시물 조회")
+	@UseGuards({MemberGuard.class})
+	public ResponseDto<PostReadResponse> read(
+		@Parameter(description = "조회할 게시물 id", example = "62d0e871-500c-45f2-893a-4f90fee5da99") @RequestParam UUID postId) {
+		PostReadResponse response = postManageUsecase.readPost(MemberContext.getMember().id(), postId);
+		return ResponseDto.of(HttpStatus.OK.value(), READ_SUCCESS.getMessage(), response);
+	}
 
-    @GetMapping()
-    @Operation(summary = "토큰 없이 게시물 조회")
-    public ResponseDto<PostReadResponse> readNoToken(
-            @Parameter(description = "조회할 게시물 id", example = "62d0e871-500c-45f2-893a-4f90fee5da99") @RequestParam UUID postId) {
-        PostReadResponse response = postManageUsecase.readPostNoToken(postId);
-        return ResponseDto.of(HttpStatus.OK.value(), READ_SUCCESS.getMessage(), response);
-    }
+	@GetMapping()
+	@Operation(summary = "토큰 없이 게시물 조회")
+	public ResponseDto<PostReadResponse> readNoToken(
+		@Parameter(description = "조회할 게시물 id", example = "62d0e871-500c-45f2-893a-4f90fee5da99") @RequestParam UUID postId) {
+		PostReadResponse response = postManageUsecase.readPostNoToken(postId);
+		return ResponseDto.of(HttpStatus.OK.value(), READ_SUCCESS.getMessage(), response);
+	}
 
-    @GetMapping("/all/token")
-    @Operation(summary = "게시물 리스트 조회")
-    @UseGuards({MemberGuard.class})
-    public ResponseDto<List<PostReadAllResponse>> readAll(
-            @Parameter(description = "페이지당 항목 수", example = "10") @RequestParam int size,
-            @Parameter(description = "조회할 페이지 번호", example = "1") @RequestParam int page) {
-        List<PostReadAllResponse> response = postManageUsecase.readAllPost(MemberContext.getMember()
-                .id(), size, page);
-        return ResponseDto.of(HttpStatus.OK.value(), READ_SUCCESS.getMessage(), response);
-    }
+	@GetMapping("/all/token")
+	@Operation(summary = "게시물 리스트 조회")
+	@UseGuards({MemberGuard.class})
+	public ResponseDto<PostReadAllResponse> readAll(
+		@Parameter(description = "페이지당 항목 수", example = "10") @RequestParam int size,
+		@Parameter(description = "조회할 페이지 번호", example = "1") @RequestParam int page) {
+		PostReadAllResponse response = postManageUsecase.readAllPost(MemberContext.getMember()
+			.id(), size, page);
+		return ResponseDto.of(HttpStatus.OK.value(), READ_SUCCESS.getMessage(), response);
+	}
 
-    @GetMapping("/all")
-    @Operation(summary = "게시물 리스트 조회")
-    public ResponseDto<List<PostReadAllResponse>> readAllNoToken(
-            @Parameter(description = "페이지당 항목 수", example = "10") @RequestParam int size,
-            @Parameter(description = "조회할 페이지 번호", example = "1") @RequestParam int page) {
-        List<PostReadAllResponse> response = postManageUsecase.readAllPostNoToken(size, page);
-        return ResponseDto.of(HttpStatus.OK.value(), READ_SUCCESS.getMessage(), response);
-    }
+	@GetMapping("/all")
+	@Operation(summary = "게시물 리스트 조회")
+	public ResponseDto<PostReadAllResponse> readAllNoToken(
+		@Parameter(description = "페이지당 항목 수", example = "10") @RequestParam int size,
+		@Parameter(description = "조회할 페이지 번호", example = "1") @RequestParam int page) {
+		PostReadAllResponse response = postManageUsecase.readAllPostNoToken(size, page);
+		return ResponseDto.of(HttpStatus.OK.value(), READ_SUCCESS.getMessage(), response);
+	}
 
-    @PatchMapping()
-    @Operation(summary = "게시물 업데이트")
-    @UseGuards({MemberGuard.class})
-    public ResponseDto<Void> update(
-            @Parameter(description = "수정할 게시물 id", example = "62d0e871-500c-45f2-893a-4f90fee5da99") @RequestParam UUID postId,
-            @Valid @RequestBody PostUpdateRequest dto) {
-        postManageUsecase.updatePost(MemberContext.getMember().id(), postId, dto);
-        return ResponseDto.of(HttpStatus.OK.value(), UPDATE_SUCCESS.getMessage());
-    }
+	@PatchMapping()
+	@Operation(summary = "게시물 업데이트")
+	@UseGuards({MemberGuard.class})
+	public ResponseDto<Void> update(
+		@Parameter(description = "수정할 게시물 id", example = "62d0e871-500c-45f2-893a-4f90fee5da99") @RequestParam UUID postId,
+		@Valid @RequestBody PostUpdateRequest dto) {
+		postManageUsecase.updatePost(MemberContext.getMember().id(), postId, dto);
+		return ResponseDto.of(HttpStatus.OK.value(), UPDATE_SUCCESS.getMessage());
+	}
 
-    @DeleteMapping()
-    @Operation(summary = "게시물 삭제")
-    @UseGuards({MemberGuard.class})
-    public ResponseDto<Void> delete(
-            @Parameter(description = "삭제할 게시물 id", example = "62d0e871-500c-45f2-893a-4f90fee5da99") @RequestParam UUID postId) {
-        postManageUsecase.deletePost(MemberContext.getMember().id(), postId);
-        return ResponseDto.of(HttpStatus.OK.value(), DELETE_SUCCESS.getMessage());
-    }
+	@DeleteMapping()
+	@Operation(summary = "게시물 삭제")
+	@UseGuards({MemberGuard.class})
+	public ResponseDto<Void> delete(
+		@Parameter(description = "삭제할 게시물 id", example = "62d0e871-500c-45f2-893a-4f90fee5da99") @RequestParam UUID postId) {
+		postManageUsecase.deletePost(MemberContext.getMember().id(), postId);
+		return ResponseDto.of(HttpStatus.OK.value(), DELETE_SUCCESS.getMessage());
+	}
 }


### PR DESCRIPTION
## 🚀 PR 요약
dto 구조 변경

## ✨ PR 상세 내용
```Json
{
  "code": 200,
  "message": "게시물 조회에 성공했습니다",
  "data": {
    "post": [
      {
        "postId": "7f8f716f-de8f-4c14-9092-3cdd707b449b",
        "title": "블로그 게시물 제목5",
        "contents": [
          {
            "contentOrder": 1,
            "content": "게시물 내용",
            "contentType": "IMAGE"
          },
          {
            "contentOrder": 2,
            "content": "게시물 내용2",
            "contentType": "TEXT"
          },
          {
            "contentOrder": 3,
            "content": "게시물 내용3",
            "contentType": "TEXT"
          }
        ],
        "isOwner": true,
        "comments": [],
        "nickName": "우악",
        "profileUrl": "url",
        "createdAt": "2025-05-07T23:28:06.929597"
      },
      {
        "postId": "19e5e498-2617-4059-ac1e-2ddce51677e2",
        "title": "블로그 게시물 제목4",
        "contents": [
          {
            "contentOrder": 1,
            "content": "게시물 내용",
            "contentType": "IMAGE"
          },
          {
            "contentOrder": 2,
            "content": "게시물 내용2",
            "contentType": "TEXT"
  
```

해당 구조로 Dto 변경
## 🚨 주의 사항
없습니다

